### PR TITLE
[GAIA-2888] Make usage of Class types inside namespaces possible

### DIFF
--- a/dynabuffers-java/src/main/kotlin/dynabuffers/Registry.kt
+++ b/dynabuffers-java/src/main/kotlin/dynabuffers/Registry.kt
@@ -1,0 +1,49 @@
+package dynabuffers
+
+import dynabuffers.api.IAnnotation
+import dynabuffers.api.IRegistry
+import dynabuffers.api.ISerializable
+import dynabuffers.api.IType
+import dynabuffers.ast.ClassType
+import dynabuffers.ast.EnumType
+import dynabuffers.ast.UnionType
+import dynabuffers.ast.annotation.*
+import dynabuffers.ast.structural.Annotation
+import dynabuffers.exception.DynabuffersException
+
+class Registry(
+    private val tree: List<IType>,
+    private val listeners: ArrayList<(String) -> Unit>
+) : IRegistry {
+
+    override fun resolveAnnotation(annotation: Annotation): IAnnotation {
+        when (annotation.options.name) {
+            "NotBlank" -> return NotBlank(annotation.options.values)
+            "MinLength" -> return MinLength(annotation.options.values)
+            "MaxLength" -> return MaxLength(annotation.options.values)
+            "GreaterThan" -> return GreaterThan(annotation.options.values)
+            "GreaterEquals" -> return GreaterEquals(annotation.options.values)
+            "LowerThan" -> return LowerThan(annotation.options.values)
+            "LowerEquals" -> return LowerEquals(annotation.options.values)
+            else -> throw DynabuffersException("unknown annotation ${annotation.options.name}")
+        }
+    }
+
+    override fun addNotification(notification: String) {
+        listeners.forEach { it(notification) }
+    }
+
+    override fun createForSchema(schema: List<IType>): IRegistry {
+        return Registry(schema, listeners)
+    }
+
+    override fun resolve(name: String): ISerializable {
+        return tree.filterIsInstance<ISerializable>().find {
+            if (it is ClassType && it.options.name == name) return@find true
+            if (it is EnumType && it.options.name == name) return@find true
+            if (it is UnionType && it.options.name == name) return@find true
+
+            return@find false
+        } ?: throw DynabuffersException("invalid reference $name")
+    }
+}

--- a/dynabuffers-java/src/main/kotlin/dynabuffers/api/IRegistry.kt
+++ b/dynabuffers-java/src/main/kotlin/dynabuffers/api/IRegistry.kt
@@ -7,4 +7,5 @@ interface IRegistry {
     fun resolve(name: String): ISerializable
     fun resolveAnnotation(annotation: Annotation):IAnnotation
     fun addNotification(notification: String)
+    fun createForSchema(schema: List<IType>):IRegistry
 }

--- a/dynabuffers-java/src/test/kotlin/dynabuffers/usecase/Schema24Test.kt
+++ b/dynabuffers-java/src/test/kotlin/dynabuffers/usecase/Schema24Test.kt
@@ -1,0 +1,27 @@
+package dynabuffers.usecase
+
+import dynabuffers.AbstractDynabuffersTest
+import dynabuffers.Dynabuffers
+import dynabuffers.DynabuffersEngine
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+
+class Schema24Test : AbstractDynabuffersTest() {
+
+    lateinit var engine: DynabuffersEngine;
+
+    @BeforeEach
+    fun setUp() {
+        engine = Dynabuffers.parse(Schema08Test::class.java.getResourceAsStream("/schema24.dbs"))
+    }
+
+   @Test
+   fun `the usual stuff`() {
+       val reference = mapOf<String,Any>("ner" to arrayOf(mapOf("text" to "asdf1234")))
+       val serialized = engine.serialize(reference)
+       val deserialized = engine.deserialize(serialized)
+       Assertions.assertThat(deserialized["ner"]).isEqualTo(reference["ner"])
+   }
+}

--- a/dynabuffers-java/src/test/resources/schema24.dbs
+++ b/dynabuffers-java/src/test/resources/schema24.dbs
@@ -1,0 +1,10 @@
+namespace outgoing {
+    class Response {
+      ner: [NERResult]
+    }
+
+    class NERResult {
+        @NotBlank
+        text: string
+    }
+}

--- a/dynabuffers-python/dynabuffers/DynabuffersEngine.py
+++ b/dynabuffers-python/dynabuffers/DynabuffersEngine.py
@@ -2,19 +2,10 @@ from typing import Union, Any, List
 
 from dynabuffers import NAMESPACE_KEY
 from dynabuffers.NamespaceResolver import NamespaceResolver
-from dynabuffers.header.RootElement import RootElement
+from dynabuffers.Registry import Registry
 from dynabuffers.api.ISerializable import ISerializable, ByteBuffer
 from dynabuffers.api.map.DynabuffersMap import DynabuffersMap
-from dynabuffers.ast.ClassType import ClassType
-from dynabuffers.ast.EnumType import EnumType
-from dynabuffers.ast.UnionType import UnionType
-from dynabuffers.ast.annotation.GreaterEquals import GreaterEquals
-from dynabuffers.ast.annotation.GreaterThan import GreaterThan
-from dynabuffers.ast.annotation.LowerEquals import LowerEquals
-from dynabuffers.ast.annotation.LowerThan import LowerThan
-from dynabuffers.ast.annotation.MaxLength import MaxLength
-from dynabuffers.ast.annotation.MinLength import MinLength
-from dynabuffers.ast.annotation.NotBlank import NotBlank
+from dynabuffers.header.RootElement import RootElement
 
 
 class DynabuffersEngine(object):
@@ -54,40 +45,3 @@ class DynabuffersEngine(object):
         bb = ByteBuffer(len(bytes), bytes)
         registry = Registry(self.tree, self.listeners)
         return RootElement(self.tree).deserialize(bb, registry)
-
-
-class Registry(object):
-
-    def __init__(self, tree: [ISerializable], listeners):
-        self.tree = tree
-        self.listeners = listeners
-
-    def resolveAnnotation(self, name, args):
-        if name == "GreaterThan":
-            return GreaterThan(args)
-        if name == "GreaterEquals":
-            return GreaterEquals(args)
-        if name == "LowerThan":
-            return LowerThan(args)
-        if name == "LowerEquals":
-            return LowerEquals(args)
-        if name == "MaxLength":
-            return MaxLength(args)
-        if name == "MinLength":
-            return MinLength(args)
-        if name == "NotBlank":
-            return NotBlank(args)
-        raise ValueError("unknown annotation " + str(name))
-
-    def resolve(self, name: str):
-        for element in self.tree:
-            if isinstance(element, ClassType) and element.options.name == name:
-                return element
-            if isinstance(element, EnumType) and element.options.name == name:
-                return element
-            if isinstance(element, UnionType) and element.options.name == name:
-                return element
-
-    def addNotification(self, notification: str):
-        for listener in self.listeners:
-            listener(notification)

--- a/dynabuffers-python/dynabuffers/Registry.py
+++ b/dynabuffers-python/dynabuffers/Registry.py
@@ -1,0 +1,51 @@
+from dynabuffers.api.ISerializable import ISerializable
+from dynabuffers.ast.ClassType import ClassType
+from dynabuffers.ast.EnumType import EnumType
+from dynabuffers.ast.UnionType import UnionType
+from dynabuffers.ast.annotation.GreaterEquals import GreaterEquals
+from dynabuffers.ast.annotation.GreaterThan import GreaterThan
+from dynabuffers.ast.annotation.LowerEquals import LowerEquals
+from dynabuffers.ast.annotation.LowerThan import LowerThan
+from dynabuffers.ast.annotation.MaxLength import MaxLength
+from dynabuffers.ast.annotation.MinLength import MinLength
+from dynabuffers.ast.annotation.NotBlank import NotBlank
+
+
+class Registry(object):
+
+    def __init__(self, tree: [ISerializable], listeners):
+        self.tree = tree
+        self.listeners = listeners
+
+    def resolveAnnotation(self, name, args):
+        if name == "GreaterThan":
+            return GreaterThan(args)
+        if name == "GreaterEquals":
+            return GreaterEquals(args)
+        if name == "LowerThan":
+            return LowerThan(args)
+        if name == "LowerEquals":
+            return LowerEquals(args)
+        if name == "MaxLength":
+            return MaxLength(args)
+        if name == "MinLength":
+            return MinLength(args)
+        if name == "NotBlank":
+            return NotBlank(args)
+        raise ValueError("unknown annotation " + str(name))
+
+    def createForSchema(self, schema: [ISerializable]):
+        return Registry(schema, self.listeners)
+
+    def resolve(self, name: str):
+        for element in self.tree:
+            if isinstance(element, ClassType) and element.options.name == name:
+                return element
+            if isinstance(element, EnumType) and element.options.name == name:
+                return element
+            if isinstance(element, UnionType) and element.options.name == name:
+                return element
+
+    def addNotification(self, notification: str):
+        for listener in self.listeners:
+            listener(notification)

--- a/dynabuffers-python/dynabuffers/ast/ClassType.py
+++ b/dynabuffers-python/dynabuffers/ast/ClassType.py
@@ -29,10 +29,13 @@ class ClassType(ISerializable):
                 else:
                     value[field.options.name] = None
 
-        byName = lambda x: (x.options.name in value) or x.options.defaultVal is not None
-        mapper = lambda x: x.size(value[x.options.name] if x.options.name in value else x.options.defaultVal, registry)
-
-        return sum(map(mapper, filter(byName, self.options.fields)))
+        size = 0
+        for field in self.options.fields:
+            if field.options.name in value:
+                size += field.size(value[field.options.name], registry)
+            elif field.options.defaultVal is not None:
+                size += field.size(field.options.defaultVal, registry)
+        return size
 
     def serialize(self, value, buffer: ByteBuffer, registry):
         if self.options.options.is_deprecated():

--- a/dynabuffers-python/dynabuffers/ast/FieldType.py
+++ b/dynabuffers-python/dynabuffers/ast/FieldType.py
@@ -17,14 +17,14 @@ class FieldType(ISerializable):
         self.options = options
 
     def size(self, value, registry):
-        return 1 + len(str(value).encode("utf-8"))
+        return self.options.datatype.size(value, registry)
 
     def serialize(self, value, buffer: ByteBuffer, registry):
         if self.options.options:
             registry.addNotification("deprecated field " + self.options.name + " used")
 
-        for annotation in list(
-                map(lambda x: registry.resolveAnnotation(x.options.name, x.options.values), self.options.annotations)):
+        for annotation in map(lambda x: registry.resolveAnnotation(x.options.name, x.options.values),
+                              self.options.annotations):
             annotation.validate(self.options.name, value)
 
         self.options.datatype.serialize(value, buffer, registry)

--- a/dynabuffers-python/dynabuffers/ast/datatype/ArrayType.py
+++ b/dynabuffers-python/dynabuffers/ast/datatype/ArrayType.py
@@ -12,7 +12,7 @@ class ArrayType(ISerializable):
         self.options = options
 
     def size(self, value, registry):
-        s = sum(map(lambda val: self.options.datatype.size(val, registry), value))
+        s = sum([self.options.datatype.size(item, registry) for item in value])
         return 4 + s
 
     def serialize(self, value, buffer, registry):

--- a/dynabuffers-python/tests/usecase/Schema24Test.py
+++ b/dynabuffers-python/tests/usecase/Schema24Test.py
@@ -1,0 +1,22 @@
+import os
+import unittest
+
+from antlr4 import FileStream
+
+from dynabuffers.Dynabuffers import Dynabuffers
+
+
+class Schema24(unittest.TestCase):
+    root_dir = os.path.dirname(os.path.realpath(__file__))
+
+    def setUp(self):
+        self.engine = Dynabuffers.parse(FileStream(self.root_dir + "/schema24.dbs"))
+
+    def test(self):
+        obj = {"ner": [{"text": "asdf1234"}]}
+        result = self.engine.deserialize(self.engine.serialize(obj, ["outgoing"]))
+        self.assertEqual(result, obj)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/dynabuffers-python/tests/usecase/schema24.dbs
+++ b/dynabuffers-python/tests/usecase/schema24.dbs
@@ -1,0 +1,10 @@
+namespace outgoing {
+    class Response {
+      ner: [NERResult]
+    }
+
+    class NERResult {
+        @NotBlank
+        text: string
+    }
+}


### PR DESCRIPTION
(cherry picked from commit ac402ed925e82163f040e8762f448bcaad8b8780)

Das ist ein Quickfix, damit ein Class Type von einer Klasse innerhalb desselben Namespaces wieder verwendet werden kann.
Änderungen sind Hauptsächlich im RootElement, wo jedes mal bei size, serialize & deserialize für den Content (nicht für den Header) eine neue Registry erstellt wird die das Schema des verwendeten Namespaces wrappt (anstatt den gesamten Parsetree).