### PR TITLE
Fix false boolean default values

### DIFF
--- a/dynabuffers-python/dynabuffers/ast/datatype/BooleanType.py
+++ b/dynabuffers-python/dynabuffers/ast/datatype/BooleanType.py
@@ -7,7 +7,7 @@ class BooleanType(ISerializable):
         return 1
 
     def serialize(self, value, buffer, registry):
-        if value:
+        if value in [True, "true"]:
             buffer.put(bytes([1]))
         else:
             buffer.put(bytes([0]))

--- a/dynabuffers-python/tests/usecase/Schema26Test.py
+++ b/dynabuffers-python/tests/usecase/Schema26Test.py
@@ -19,7 +19,8 @@ class Schema26(unittest.TestCase):
             "twoFloat": 2.0,
             "threeShort": 3,
             "fourLong": 4,
-            "trueBoolean": True
+            "trueBoolean": True,
+            "falseBoolean": False
         }
         result = self.engine.deserialize(self.engine.serialize({}))
         self.assertEqual(result, obj)

--- a/dynabuffers-python/tests/usecase/schema26.dbs
+++ b/dynabuffers-python/tests/usecase/schema26.dbs
@@ -5,4 +5,5 @@ class Request {
     threeShort: short = 3
     fourLong: long = 4
     trueBoolean: boolean = true
+    falseBoolean: boolean = false
 }


### PR DESCRIPTION
Da die default Werte für booleans als Strings gelesen werden, wurden sowohl "true", als auch "false" als True interpretiert. Dieser commit beinhaltet einen erweiterten Test mit boolean default Wert "false" und den zugehörigen Fix.